### PR TITLE
Add export

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,18 @@ NOTE : The blueprint workspace MUST be in the root ! The blueprint name in Azure
 
 > This will preview the workspace that will be imported to Azure.
 
+To Export a blueprint :
+
+- Use command **Azure Blueprints: Export Blueprint**  
+
+### Requirement :
+
+- Blueprint name
+- Blueprint version
+- Management Group Id
+- Output path
+  > This will export your blueprints in Azure to your local drive.
+
 # Contribution
 
 This extension is open source and hosted on [Github](https://github.com/charotAmine/azureBlueprintsExtension). Contributions are more than welcome. Feel free to fork and add new features or submit bug reports.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "azure-blueprints-generator",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
 		"onCommand:extension.importBlueprint",
 		"onCommand:extension.publishBlueprint",
 		"onCommand:extension.assignBlueprint",
-		"onCommand:extension.blueprintPreview"
+		"onCommand:extension.blueprintPreview",
+		"onCommand:extension.exportBlueprint"
 	],
 	"main": "./out/extension.js",
 	"contributes": {
@@ -49,6 +50,10 @@
 			{
 				"command": "extension.blueprintPreview",
 				"title": "Azure Blueprints: Preview Blueprint"
+			},
+			{
+				"command": "extension.exportBlueprint",
+				"title": "Azure Blueprints: Export Blueprint"
 			}
 		]
 	},

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "aminecharot",
 	"displayName": "Azure Blueprints Generator",
 	"description": "Generates the directory of Azure Blueprints",
-	"version": "0.1.0",
+	"version": "0.1.1",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/charotAmine/azureBlueprintsExtension"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"publisher": "aminecharot",
 	"displayName": "Azure Blueprints Generator",
 	"description": "Generates the directory of Azure Blueprints",
-	"version": "0.1.1",
+	"version": "0.2.0",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/charotAmine/azureBlueprintsExtension"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -247,56 +247,56 @@ export function activate(context: vscode.ExtensionContext) {
         });
         if (blueprintRootName === undefined || blueprintRootName.length <= 0) {
           vscode.window.setStatusBarMessage("No Azure Blueprint name provided");
+          return;
         }
-        else {
-            let managementGroupName = await vscode.window.showInputBox({
-              value: "myManagementGroup",
-              prompt: "Management Group name",
-              placeHolder: "Management Group name",
-              password: false
-            });
-            if (
-              managementGroupName == undefined ||
-              managementGroupName.length <= 0
-            ) {
-              vscode.window.setStatusBarMessage("No management group provided");
-            }
+        let managementGroupName = await vscode.window.showInputBox({
+          value: "myManagementGroup",
+          prompt: "Management Group name",
+          placeHolder: "Management Group name",
+          password: false
+        });
+        if (
+          managementGroupName == undefined ||
+          managementGroupName.length <= 0
+        ) {
+          vscode.window.setStatusBarMessage("No management group provided");
+          return;
+        }
+        let outputPath = await vscode.window.showInputBox({
+          value: `${context.extensionPath}/`,
+          prompt: "Output export path",
+          placeHolder: "Set the output path",
+          password: false
+        });
+        if (outputPath === undefined || outputPath.length <= 0) {
+          vscode.window.setStatusBarMessage("No path provided");
+          return;
+        }
+        let version = await vscode.window.showInputBox({
+          prompt: "Assigned blueprint version",
+          placeHolder: "Set the wanted version to export",
+          password: false
+        });
+        if (
+          version === undefined ||
+          version.length <= 0
+        ) {
+          vscode.window.setStatusBarMessage("No version provided");
+          return;
+        }
+        let terminal = (<any>vscode.window).createTerminal(
+          "Import blueprint"
+        );
+        blueprintWorkspace.createDirectory(outputPath);
+        terminal.show(true);
+        terminal.sendText("POWERSHELL Login-AzAccount", true);
+        terminal.sendText(
+          `POWERSHELL $createdBlueprint = Get-AzBlueprint -ManagementGroupId ${managementGroupName} -Name ${blueprintRootName}; Export-AzBlueprintWithArtifact -Blueprint $createdBlueprint -Version ${version} -OutputPath '${outputPath}'`,
+          true
+        );
 
-        else {
-          let outputPath = await vscode.window.showInputBox({
-            value: `${context.extensionPath}/`,
-            prompt: "Output export path",
-            placeHolder: "Set the output path",
-            password: false
-          });
-          if (outputPath === undefined || outputPath.length <= 0) {
-            vscode.window.setStatusBarMessage("No path provided");
-          } else {
-            let version = await vscode.window.showInputBox({
-              prompt: "Assigned blueprint version",
-              placeHolder: "Set the wanted version to export",
-              password: false
-            });
-            if (
-              version === undefined ||
-              version.length <= 0
-            ) {
-              vscode.window.setStatusBarMessage("No version provided");
-            } else {
-              let terminal = (<any>vscode.window).createTerminal(
-                "Import blueprint"
-              );
-              blueprintWorkspace.createDirectory(outputPath);
-              terminal.show(true);
-              terminal.sendText("POWERSHELL Login-AzAccount", true);
-              terminal.sendText(
-                `POWERSHELL $createdBlueprint = Get-AzBlueprint -ManagementGroupId ${managementGroupName} -Name ${blueprintRootName}; Export-AzBlueprintWithArtifact -Blueprint $createdBlueprint -Version ${version} -OutputPath '${outputPath}'`,
-                true
-              );
-              }
-          }
-        }
-      }
+
+
       } catch (err) {
         if (err && err.message) {
           vscode.window.showErrorMessage(err.message);
@@ -313,4 +313,4 @@ export function activate(context: vscode.ExtensionContext) {
   context.subscriptions.push(previewCommand);
 }
 
-export function deactivate() {}
+export function deactivate() { }

--- a/src/fileController.ts
+++ b/src/fileController.ts
@@ -40,7 +40,7 @@ export class FileController {
     }
   }
 
-  private async createDirectory(dirName: string): Promise<string> {
+  public async createDirectory(dirName: string): Promise<string> {
     await mkdir(dirName);
     return dirName;
   }
@@ -63,7 +63,7 @@ export class FileController {
     return newFileName;
   }
 
-  private async fileExists(path: string): Promise<boolean> {
+  public async fileExists(path: string): Promise<boolean> {
     return new Promise((resolve, reject) => {
       fs.exists(path, exists => {
         resolve(exists);


### PR DESCRIPTION
Add the ability to export an Azure Blueprints already imported on Azure in order to apply the reverse engineering so that the user can switch to blueprints as code